### PR TITLE
Fix docker compose env for API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 node_modules
 dist
 .env
-.env.docker
 !.env.example
 
 *.log

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -15,10 +15,9 @@ services:
       context: ../../panel-turnos-api
     env_file:
       - ../../panel-turnos-api/.env.docker   # contiene DATABASE_URL con host "db"
-    volumes:                                 # monta el mismo fichero dentro
-      - ../../panel-turnos-api/.env.docker:/app/.env:ro
     ports: [ "3000:3000", "5555:5555" ]
     depends_on: [ db ]
+    command: sh -c "npx prisma migrate deploy && node dist/main.js"
 
 volumes:
   pgdata:

--- a/panel-turnos-api/.env.docker
+++ b/panel-turnos-api/.env.docker
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://app:secret@db:5432/panel_turnos"
+PORT=3000


### PR DESCRIPTION
## Summary
- add `.env.docker` with default DATABASE_URL and port
- auto run Prisma migrations on API container start
- track `.env.docker` by adjusting `.gitignore`

## Testing
- `npm run build`
- `export $(cat .env.docker | xargs) && npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68c690ed8ab08321a4a73ed8e08f01c0