### PR TITLE
feat: ensure API starts with prisma fallback

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - ../../panel-turnos-api/.env.docker   # contiene DATABASE_URL con host "db"
     ports: [ "3000:3000", "5555:5555" ]
     depends_on: [ db ]
-    command: sh -c "npx prisma migrate deploy && node dist/main.js"
+    command: ./start.sh
 
 volumes:
   pgdata:

--- a/panel-turnos-api/Dockerfile
+++ b/panel-turnos-api/Dockerfile
@@ -18,7 +18,9 @@ ENV NODE_ENV=production
 COPY --from=deps  /app/node_modules ./node_modules
 COPY --from=build /app/dist          ./dist
 COPY --from=build /app/prisma        ./prisma
+COPY --from=build /app/start.sh      ./start.sh
+RUN chmod +x ./start.sh
 
 # el .env se monta como volumen en docker-compose, no se copia aquí
 EXPOSE 3000
-CMD ["node", "dist/main.js"]
+CMD ["./start.sh"]

--- a/panel-turnos-api/start.sh
+++ b/panel-turnos-api/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+npx prisma migrate deploy || npx prisma db push
+exec node dist/main.js


### PR DESCRIPTION
## Summary
- add startup script that runs `prisma migrate deploy` with fallback to `db push`
- use the script as Docker CMD for api service
- update docker-compose to invoke the new script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `docker compose build` *(fails: command not found: docker)*
- `docker compose up -d` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c6962a9d308321a7326b0c3cf496b5