### PR TITLE
chore: track prisma migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,6 @@ dist
 # Docker
 infra/docker/pgdata
 
-# Prisma
-prisma/migrations
-
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- stop ignoring Prisma migrations to track them in git

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c699a47f7c8321be50face4f13de7d